### PR TITLE
Changes (possibly) required for upcoming CoffeeScript upgrade

### DIFF
--- a/lib/quick-editor.coffee
+++ b/lib/quick-editor.coffee
@@ -64,14 +64,14 @@ module.exports = QuickEditor =
 
   findFilesFromCSSIdentifier:(identifier) ->
     @searcher.findFilesThatContain identifier
-    .then () => @searcher.getSelectorText().then ([found, result]) =>
+    .then () => (@searcher.getSelectorText().then ([found, result]) =>
         @found = found
         @searcher.clear()
         if found
           path = atom.workspace.getActiveTextEditor().getPath()
           @cssCache.put(path, result.file.getPath())
         return [found, result]
-    .catch (e) ->
+    ).catch (e) ->
       console.error(e.message, e.stack)
 
   parseSelectedCSSSelector: ->


### PR DESCRIPTION
Hello!

In Atom 1.23.0, the CoffeeScript dependency [will be upgraded from version 1.11.1 to 1.12.7](https://github.com/atom/atom/pull/13731). To ensure that all packages will remain working the same way, we searched for CoffeeScript compile output differences from all Atom packages and found your package to be potentially affected by the update.

This pull request implements the fix mentioned in https://github.com/jashkenas/coffeescript/issues/4760#issuecomment-340001235, which is compatible with both versions.

It feels to me that the current code will remain working despite the compiled output takes slightly different approach. If you believe this is the case, feel free to just close this pull request and consider this just as a heads-up.

Please let me know if you have any questions.